### PR TITLE
Improved side nav config

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -74,9 +74,6 @@ params:
   ui:
     navbar_logo: true
     showLightDarkModeMenu: true
-    sidebar_cache_limit: 10
-    sidebar_menu_compact: true
-    sidebar_menu_foldable: false
     sidebar_search_disable: true
     feedback: # CUSTOMIZE
       enable: false # FIXME: setting to false until the feedback can be better configured


### PR DESCRIPTION
No need, for such a small site, to impose any cache limit nor to make the left side nav compact. This PR adjusts the main Hugo config accordingly.